### PR TITLE
createEmoji: Fix imports

### DIFF
--- a/createEmoji/index.js
+++ b/createEmoji/index.js
@@ -1,6 +1,6 @@
-import {webpackModules} from "@goosemod/discord";
+import * as webpackModules from "@goosemod/webpack";
 import * as logger from "@goosemod/logger";
-import * as showToast from "@goosemod/toast";
+import showToast from "@goosemod/toast";
 
 let unpatch;
 


### PR DESCRIPTION
Fix imports for `showToast` and `webpackModules` for `createEmoji` module.